### PR TITLE
feat: Add backend user profile management (closes #42)

### DIFF
--- a/apps/backend/migrations/V2__add_profiles_table.sql
+++ b/apps/backend/migrations/V2__add_profiles_table.sql
@@ -1,0 +1,24 @@
+-- Create profiles table
+CREATE TABLE profiles (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id UUID NOT NULL UNIQUE,
+    first_name VARCHAR(100) NOT NULL DEFAULT '',
+    last_name VARCHAR(100) NOT NULL DEFAULT '',
+    phone VARCHAR(20) NOT NULL DEFAULT '',
+    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT fk_profile_user FOREIGN KEY (user_id)
+        REFERENCES users(id) ON DELETE CASCADE
+);
+
+-- Create index on user_id for faster lookups
+CREATE INDEX idx_profiles_user_id ON profiles(user_id);
+
+-- Backfill existing users with empty profiles
+INSERT INTO profiles (user_id, first_name, last_name, phone)
+SELECT id, '', '', ''
+FROM users
+WHERE NOT EXISTS (
+    SELECT 1 FROM profiles WHERE profiles.user_id = users.id
+);

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -38,6 +38,7 @@ model User {
   properties   Property[]
   persons      Person[]
   leases       Lease[]
+  profile      Profile?
 
   @@map("users")
 }
@@ -153,4 +154,20 @@ model LeaseOccupant {
   @@index([leaseId])
   @@index([personId])
   @@map("lease_occupants")
+}
+
+model Profile {
+  id        String   @id @default(uuid())
+  userId    String   @unique @map("user_id")
+  firstName String   @default("") @map("first_name") @db.VarChar(100)
+  lastName  String   @default("") @map("last_name") @db.VarChar(100)
+  phone     String   @default("") @db.VarChar(20)
+  createdAt DateTime @default(now()) @map("created_at")
+  updatedAt DateTime @updatedAt @map("updated_at")
+
+  // Relations
+  user      User     @relation(fields: [userId], references: [id], onDelete: Cascade)
+
+  @@index([userId])
+  @@map("profiles")
 }

--- a/apps/backend/src/application/profile/GetProfileUseCase.ts
+++ b/apps/backend/src/application/profile/GetProfileUseCase.ts
@@ -1,0 +1,28 @@
+import { injectable, inject } from 'inversify';
+import { IProfileRepository } from '../../domain/repositories';
+import { Profile } from '@domain/entities';
+
+interface GetProfileInput {
+  userId: string;
+}
+
+@injectable()
+export class GetProfileUseCase {
+  constructor(
+    @inject('IProfileRepository') private profileRepository: IProfileRepository
+  ) {}
+
+  async execute(input: GetProfileInput): Promise<Profile> {
+    // Try to get existing profile
+    let profile = await this.profileRepository.findByUserId(input.userId);
+
+    // If no profile exists, create an empty one
+    if (!profile) {
+      profile = await this.profileRepository.create({
+        userId: input.userId,
+      });
+    }
+
+    return profile;
+  }
+}

--- a/apps/backend/src/application/profile/GetProfileUseCase.unit.test.ts
+++ b/apps/backend/src/application/profile/GetProfileUseCase.unit.test.ts
@@ -1,0 +1,84 @@
+import { GetProfileUseCase } from './GetProfileUseCase';
+import { IProfileRepository } from '../../domain/repositories';
+import { Profile } from '@domain/entities';
+
+describe('GetProfileUseCase', () => {
+  let getProfileUseCase: GetProfileUseCase;
+  let mockProfileRepository: jest.Mocked<IProfileRepository>;
+
+  beforeEach(() => {
+    mockProfileRepository = {
+      findByUserId: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    };
+
+    getProfileUseCase = new GetProfileUseCase(mockProfileRepository);
+  });
+
+  describe('execute', () => {
+    it('should return existing profile when it exists', async () => {
+      const userId = 'user-123';
+
+      const mockProfile: Profile = {
+        id: 'profile-123',
+        userId,
+        firstName: 'John',
+        lastName: 'Doe',
+        phone: '1234567890',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockProfileRepository.findByUserId.mockResolvedValue(mockProfile);
+
+      const result = await getProfileUseCase.execute({ userId });
+
+      expect(mockProfileRepository.findByUserId).toHaveBeenCalledWith(userId);
+      expect(mockProfileRepository.create).not.toHaveBeenCalled();
+      expect(result).toEqual(mockProfile);
+    });
+
+    it('should create and return empty profile when none exists', async () => {
+      const userId = 'user-456';
+
+      const newProfile: Profile = {
+        id: 'profile-456',
+        userId,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockProfileRepository.findByUserId.mockResolvedValue(null);
+      mockProfileRepository.create.mockResolvedValue(newProfile);
+
+      const result = await getProfileUseCase.execute({ userId });
+
+      expect(mockProfileRepository.findByUserId).toHaveBeenCalledWith(userId);
+      expect(mockProfileRepository.create).toHaveBeenCalledWith({ userId });
+      expect(result).toEqual(newProfile);
+    });
+
+    it('should return profile with all fields populated', async () => {
+      const userId = 'user-789';
+
+      const mockProfile: Profile = {
+        id: 'profile-789',
+        userId,
+        firstName: 'Jane',
+        lastName: 'Smith',
+        phone: '5551234567',
+        createdAt: new Date('2024-01-01'),
+        updatedAt: new Date('2024-01-15'),
+      };
+
+      mockProfileRepository.findByUserId.mockResolvedValue(mockProfile);
+
+      const result = await getProfileUseCase.execute({ userId });
+
+      expect(result.firstName).toBe('Jane');
+      expect(result.lastName).toBe('Smith');
+      expect(result.phone).toBe('5551234567');
+    });
+  });
+});

--- a/apps/backend/src/application/profile/UpdateProfileUseCase.ts
+++ b/apps/backend/src/application/profile/UpdateProfileUseCase.ts
@@ -1,0 +1,43 @@
+import { injectable, inject } from 'inversify';
+import { IProfileRepository } from '../../domain/repositories';
+import { ValidationError } from '@domain/errors';
+import { updateProfileSchema } from '@validators/profile';
+import { Profile } from '@domain/entities';
+
+interface UpdateProfileInput {
+  userId: string;
+  firstName?: string;
+  lastName?: string;
+  phone?: string;
+}
+
+@injectable()
+export class UpdateProfileUseCase {
+  constructor(
+    @inject('IProfileRepository') private profileRepository: IProfileRepository
+  ) {}
+
+  async execute(input: UpdateProfileInput): Promise<Profile> {
+    // Extract update data (excluding userId)
+    const { userId, ...updateData } = input;
+
+    // Validate update data using shared schema
+    const validation = updateProfileSchema.safeParse(updateData);
+    if (!validation.success) {
+      throw new ValidationError(validation.error.errors[0].message);
+    }
+
+    // Get or create profile
+    let profile = await this.profileRepository.findByUserId(userId);
+
+    if (!profile) {
+      // Create empty profile if doesn't exist
+      profile = await this.profileRepository.create({ userId });
+    }
+
+    // Update profile with validated data
+    const updatedProfile = await this.profileRepository.update(userId, updateData);
+
+    return updatedProfile;
+  }
+}

--- a/apps/backend/src/application/profile/UpdateProfileUseCase.unit.test.ts
+++ b/apps/backend/src/application/profile/UpdateProfileUseCase.unit.test.ts
@@ -1,0 +1,207 @@
+import { UpdateProfileUseCase } from './UpdateProfileUseCase';
+import { IProfileRepository } from '../../domain/repositories';
+import { ValidationError } from '@domain/errors';
+import { Profile } from '@domain/entities';
+
+describe('UpdateProfileUseCase', () => {
+  let updateProfileUseCase: UpdateProfileUseCase;
+  let mockProfileRepository: jest.Mocked<IProfileRepository>;
+
+  beforeEach(() => {
+    mockProfileRepository = {
+      findByUserId: jest.fn(),
+      create: jest.fn(),
+      update: jest.fn(),
+    };
+
+    updateProfileUseCase = new UpdateProfileUseCase(mockProfileRepository);
+  });
+
+  describe('execute', () => {
+    it('should update profile with valid input', async () => {
+      const userId = 'user-123';
+      const updateData = {
+        firstName: 'John',
+        lastName: 'Doe',
+        phone: '1234567890',
+      };
+
+      const existingProfile: Profile = {
+        id: 'profile-123',
+        userId,
+        firstName: 'Jane',
+        lastName: 'Smith',
+        phone: '5551234567',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      const updatedProfile: Profile = {
+        ...existingProfile,
+        firstName: updateData.firstName,
+        lastName: updateData.lastName,
+        phone: updateData.phone,
+        updatedAt: new Date(),
+      };
+
+      mockProfileRepository.findByUserId.mockResolvedValue(existingProfile);
+      mockProfileRepository.update.mockResolvedValue(updatedProfile);
+
+      const result = await updateProfileUseCase.execute({ userId, ...updateData });
+
+      expect(mockProfileRepository.findByUserId).toHaveBeenCalledWith(userId);
+      expect(mockProfileRepository.update).toHaveBeenCalledWith(userId, updateData);
+      expect(result).toEqual(updatedProfile);
+    });
+
+    it('should throw ValidationError when firstName > 100 chars', async () => {
+      const userId = 'user-123';
+      const updateData = {
+        firstName: 'A'.repeat(101),
+      };
+
+      const existingProfile: Profile = {
+        id: 'profile-123',
+        userId,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockProfileRepository.findByUserId.mockResolvedValue(existingProfile);
+
+      await expect(
+        updateProfileUseCase.execute({ userId, ...updateData })
+      ).rejects.toThrow(ValidationError);
+
+      expect(mockProfileRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('should throw ValidationError when phone < 10 chars', async () => {
+      const userId = 'user-123';
+      const updateData = {
+        phone: '123456789', // 9 digits
+      };
+
+      const existingProfile: Profile = {
+        id: 'profile-123',
+        userId,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockProfileRepository.findByUserId.mockResolvedValue(existingProfile);
+
+      await expect(
+        updateProfileUseCase.execute({ userId, ...updateData })
+      ).rejects.toThrow(ValidationError);
+
+      expect(mockProfileRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('should create profile if not exists, then update', async () => {
+      const userId = 'user-456';
+      const updateData = {
+        firstName: 'Alice',
+      };
+
+      const newProfile: Profile = {
+        id: 'profile-456',
+        userId,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      const updatedProfile: Profile = {
+        ...newProfile,
+        firstName: updateData.firstName,
+        updatedAt: new Date(),
+      };
+
+      mockProfileRepository.findByUserId.mockResolvedValue(null);
+      mockProfileRepository.create.mockResolvedValue(newProfile);
+      mockProfileRepository.update.mockResolvedValue(updatedProfile);
+
+      const result = await updateProfileUseCase.execute({ userId, ...updateData });
+
+      expect(mockProfileRepository.findByUserId).toHaveBeenCalledWith(userId);
+      expect(mockProfileRepository.create).toHaveBeenCalledWith({ userId });
+      expect(mockProfileRepository.update).toHaveBeenCalledWith(userId, updateData);
+      expect(result).toEqual(updatedProfile);
+    });
+
+    it('should allow partial update (only updates provided fields)', async () => {
+      const userId = 'user-789';
+      const updateData = {
+        firstName: 'Bob',
+      };
+
+      const existingProfile: Profile = {
+        id: 'profile-789',
+        userId,
+        firstName: 'Alice',
+        lastName: 'Johnson',
+        phone: '5551234567',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      const updatedProfile: Profile = {
+        ...existingProfile,
+        firstName: updateData.firstName,
+        updatedAt: new Date(),
+      };
+
+      mockProfileRepository.findByUserId.mockResolvedValue(existingProfile);
+      mockProfileRepository.update.mockResolvedValue(updatedProfile);
+
+      const result = await updateProfileUseCase.execute({ userId, ...updateData });
+
+      expect(mockProfileRepository.update).toHaveBeenCalledWith(userId, updateData);
+      expect(result.firstName).toBe('Bob');
+    });
+
+    it('should throw ValidationError when empty string provided for firstName', async () => {
+      const userId = 'user-123';
+      const updateData = {
+        firstName: '', // Empty string not allowed when provided
+      };
+
+      const existingProfile: Profile = {
+        id: 'profile-123',
+        userId,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockProfileRepository.findByUserId.mockResolvedValue(existingProfile);
+
+      await expect(
+        updateProfileUseCase.execute({ userId, ...updateData })
+      ).rejects.toThrow(ValidationError);
+
+      expect(mockProfileRepository.update).not.toHaveBeenCalled();
+    });
+
+    it('should accept empty object (no update)', async () => {
+      const userId = 'user-123';
+
+      const existingProfile: Profile = {
+        id: 'profile-123',
+        userId,
+        firstName: 'John',
+        lastName: 'Doe',
+        phone: '1234567890',
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      };
+
+      mockProfileRepository.findByUserId.mockResolvedValue(existingProfile);
+      mockProfileRepository.update.mockResolvedValue(existingProfile);
+
+      const result = await updateProfileUseCase.execute({ userId });
+
+      expect(mockProfileRepository.update).toHaveBeenCalledWith(userId, {});
+      expect(result).toEqual(existingProfile);
+    });
+  });
+});

--- a/apps/backend/src/application/profile/index.ts
+++ b/apps/backend/src/application/profile/index.ts
@@ -1,0 +1,2 @@
+export { GetProfileUseCase } from './GetProfileUseCase';
+export { UpdateProfileUseCase } from './UpdateProfileUseCase';

--- a/apps/backend/src/container.ts
+++ b/apps/backend/src/container.ts
@@ -1,13 +1,13 @@
 import { Container } from 'inversify';
 
 // Domain interfaces
-import { IUserRepository, IPropertyRepository } from './domain/repositories';
+import { IUserRepository, IPropertyRepository, IProfileRepository } from './domain/repositories';
 import { IPersonRepository } from './domain/repositories/IPersonRepository';
 import { ILeaseRepository } from './domain/repositories/ILeaseRepository';
 import { IPasswordHasher, ITokenGenerator, ILogger } from './domain/services';
 
 // Infrastructure implementations
-import { PrismaUserRepository, PrismaPropertyRepository } from './infrastructure/repositories';
+import { PrismaUserRepository, PrismaPropertyRepository, PrismaProfileRepository } from './infrastructure/repositories';
 import { PrismaPersonRepository } from './infrastructure/repositories/PrismaPersonRepository';
 import { PrismaLeaseRepository } from './infrastructure/repositories/PrismaLeaseRepository';
 import { BcryptPasswordHasher, JwtTokenGenerator, ConsoleLogger } from './infrastructure/services';
@@ -21,6 +21,7 @@ import {
   UpdatePropertyUseCase,
   DeletePropertyUseCase,
 } from './application/property';
+import { GetProfileUseCase, UpdateProfileUseCase } from './application/profile';
 import { CreateLeaseUseCase } from './application/lease/CreateLeaseUseCase';
 import { GetLeaseByIdUseCase } from './application/lease/GetLeaseByIdUseCase';
 import { UpdateLeaseUseCase } from './application/lease/UpdateLeaseUseCase';
@@ -33,7 +34,7 @@ import { AddOccupantToLeaseUseCase } from './application/lease/AddOccupantToLeas
 import { RemoveOccupantFromLeaseUseCase } from './application/lease/RemoveOccupantFromLeaseUseCase';
 
 // Controllers
-import { AuthController, PropertyController } from './presentation/controllers';
+import { AuthController, PropertyController, ProfileController } from './presentation/controllers';
 import { LeaseController } from './presentation/controllers/LeaseController';
 
 export function createContainer(): Container {
@@ -58,6 +59,11 @@ export function createContainer(): Container {
   container
     .bind<ILeaseRepository>('ILeaseRepository')
     .to(PrismaLeaseRepository)
+    .inTransientScope();
+
+  container
+    .bind<IProfileRepository>('IProfileRepository')
+    .to(PrismaProfileRepository)
     .inTransientScope();
 
   // Bind services
@@ -96,10 +102,14 @@ export function createContainer(): Container {
   container.bind(AddOccupantToLeaseUseCase).toSelf().inTransientScope();
   container.bind(RemoveOccupantFromLeaseUseCase).toSelf().inTransientScope();
 
+  container.bind(GetProfileUseCase).toSelf().inTransientScope();
+  container.bind(UpdateProfileUseCase).toSelf().inTransientScope();
+
   // Bind controllers
   container.bind(AuthController).toSelf().inTransientScope();
   container.bind(PropertyController).toSelf().inTransientScope();
   container.bind(LeaseController).toSelf().inTransientScope();
+  container.bind(ProfileController).toSelf().inTransientScope();
 
   return container;
 }

--- a/apps/backend/src/domain/repositories/IProfileRepository.ts
+++ b/apps/backend/src/domain/repositories/IProfileRepository.ts
@@ -1,0 +1,7 @@
+import { Profile, CreateProfileData } from '@domain/entities';
+
+export interface IProfileRepository {
+  findByUserId(userId: string): Promise<Profile | null>;
+  create(data: CreateProfileData): Promise<Profile>;
+  update(userId: string, data: Partial<Profile>): Promise<Profile>;
+}

--- a/apps/backend/src/domain/repositories/index.ts
+++ b/apps/backend/src/domain/repositories/index.ts
@@ -1,2 +1,3 @@
 export { IUserRepository } from './IUserRepository';
 export { IPropertyRepository } from './IPropertyRepository';
+export { IProfileRepository } from './IProfileRepository';

--- a/apps/backend/src/infrastructure/repositories/PrismaProfileRepository.ts
+++ b/apps/backend/src/infrastructure/repositories/PrismaProfileRepository.ts
@@ -1,0 +1,73 @@
+import { injectable } from 'inversify';
+import { PrismaClient } from '@prisma/client';
+import { IProfileRepository } from '../../domain/repositories/IProfileRepository';
+import { Profile, CreateProfileData } from '@upkeep-io/domain';
+
+@injectable()
+export class PrismaProfileRepository implements IProfileRepository {
+  private prisma: PrismaClient;
+
+  constructor() {
+    this.prisma = new PrismaClient();
+  }
+
+  async findByUserId(userId: string): Promise<Profile | null> {
+    const profile = await this.prisma.profile.findUnique({
+      where: { userId },
+    });
+
+    if (!profile) return null;
+
+    return {
+      id: profile.id,
+      userId: profile.userId,
+      firstName: profile.firstName ?? undefined,
+      lastName: profile.lastName ?? undefined,
+      phone: profile.phone ?? undefined,
+      createdAt: profile.createdAt,
+      updatedAt: profile.updatedAt,
+    };
+  }
+
+  async create(data: CreateProfileData): Promise<Profile> {
+    const profile = await this.prisma.profile.create({
+      data: {
+        userId: data.userId,
+        firstName: data.firstName ?? '',
+        lastName: data.lastName ?? '',
+        phone: data.phone ?? '',
+      },
+    });
+
+    return {
+      id: profile.id,
+      userId: profile.userId,
+      firstName: profile.firstName ?? undefined,
+      lastName: profile.lastName ?? undefined,
+      phone: profile.phone ?? undefined,
+      createdAt: profile.createdAt,
+      updatedAt: profile.updatedAt,
+    };
+  }
+
+  async update(userId: string, data: Partial<Profile>): Promise<Profile> {
+    const profile = await this.prisma.profile.update({
+      where: { userId },
+      data: {
+        firstName: data.firstName,
+        lastName: data.lastName,
+        phone: data.phone,
+      },
+    });
+
+    return {
+      id: profile.id,
+      userId: profile.userId,
+      firstName: profile.firstName ?? undefined,
+      lastName: profile.lastName ?? undefined,
+      phone: profile.phone ?? undefined,
+      createdAt: profile.createdAt,
+      updatedAt: profile.updatedAt,
+    };
+  }
+}

--- a/apps/backend/src/infrastructure/repositories/index.ts
+++ b/apps/backend/src/infrastructure/repositories/index.ts
@@ -1,2 +1,3 @@
 export { PrismaUserRepository } from './PrismaUserRepository';
 export { PrismaPropertyRepository } from './PrismaPropertyRepository';
+export { PrismaProfileRepository } from './PrismaProfileRepository';

--- a/apps/backend/src/presentation/controllers/ProfileController.ts
+++ b/apps/backend/src/presentation/controllers/ProfileController.ts
@@ -1,0 +1,51 @@
+import { Response, NextFunction } from 'express';
+import { injectable, inject } from 'inversify';
+import { GetProfileUseCase, UpdateProfileUseCase } from '../../application/profile';
+import { AuthRequest } from '../middleware';
+
+@injectable()
+export class ProfileController {
+  constructor(
+    @inject(GetProfileUseCase) private getProfileUseCase: GetProfileUseCase,
+    @inject(UpdateProfileUseCase) private updateProfileUseCase: UpdateProfileUseCase
+  ) {}
+
+  async get(req: AuthRequest, res: Response, next: NextFunction): Promise<void> {
+    try {
+      if (!req.user) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+
+      const profile = await this.getProfileUseCase.execute({
+        userId: req.user.userId,
+      });
+
+      res.status(200).json(profile);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  async update(req: AuthRequest, res: Response, next: NextFunction): Promise<void> {
+    try {
+      if (!req.user) {
+        res.status(401).json({ error: 'Unauthorized' });
+        return;
+      }
+
+      const { firstName, lastName, phone } = req.body;
+
+      const profile = await this.updateProfileUseCase.execute({
+        userId: req.user.userId,
+        firstName,
+        lastName,
+        phone,
+      });
+
+      res.status(200).json(profile);
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/apps/backend/src/presentation/controllers/index.ts
+++ b/apps/backend/src/presentation/controllers/index.ts
@@ -1,2 +1,3 @@
 export { AuthController } from './AuthController';
 export { PropertyController } from './PropertyController';
+export { ProfileController } from './ProfileController';

--- a/apps/backend/src/presentation/routes/index.ts
+++ b/apps/backend/src/presentation/routes/index.ts
@@ -1,2 +1,3 @@
 export { createAuthRoutes } from './authRoutes';
 export { createPropertyRoutes } from './propertyRoutes';
+export { createProfileRoutes } from './profileRoutes';

--- a/apps/backend/src/presentation/routes/profileRoutes.ts
+++ b/apps/backend/src/presentation/routes/profileRoutes.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+import { Container } from 'inversify';
+import { ProfileController } from '../controllers';
+import { createAuthMiddleware } from '../middleware';
+
+export const createProfileRoutes = (container: Container): Router => {
+  const router = Router();
+  const profileController = container.get(ProfileController);
+  const authMiddleware = createAuthMiddleware(container);
+
+  router.use(authMiddleware);
+
+  router.get('/', (req, res, next) => profileController.get(req, res, next));
+  router.put('/', (req, res, next) => profileController.update(req, res, next));
+
+  return router;
+};

--- a/apps/backend/src/server.ts
+++ b/apps/backend/src/server.ts
@@ -9,7 +9,7 @@ import express, { Application } from 'express';
 import cors from 'cors';
 import swaggerUi from 'swagger-ui-express';
 import { createContainer } from './container';
-import { createAuthRoutes, createPropertyRoutes } from './presentation/routes';
+import { createAuthRoutes, createPropertyRoutes, createProfileRoutes } from './presentation/routes';
 import { createLeaseRoutes } from './presentation/routes/leaseRoutes';
 import { createErrorMiddleware } from './presentation/middleware';
 import { ILogger } from './domain/services';
@@ -45,6 +45,7 @@ app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerSpec, {
 app.use('/api/auth', createAuthRoutes(container));
 app.use('/api/properties', createPropertyRoutes(container));
 app.use('/api/leases', createLeaseRoutes(container));
+app.use('/api/profile', createProfileRoutes(container));
 
 // Error handling middleware (must be last)
 app.use(createErrorMiddleware(logger));

--- a/libs/domain/src/entities/Profile.ts
+++ b/libs/domain/src/entities/Profile.ts
@@ -1,0 +1,16 @@
+export interface Profile {
+  id: string;
+  userId: string;
+  firstName?: string;
+  lastName?: string;
+  phone?: string;
+  createdAt: Date;
+  updatedAt: Date;
+}
+
+export interface CreateProfileData {
+  userId: string;
+  firstName?: string;
+  lastName?: string;
+  phone?: string;
+}

--- a/libs/domain/src/entities/index.ts
+++ b/libs/domain/src/entities/index.ts
@@ -5,3 +5,4 @@ export type { Lease, LeaseWithDetails } from './Lease';
 export { LeaseStatus } from './Lease';
 export type { LeaseLessee } from './LeaseLessee';
 export type { LeaseOccupant } from './LeaseOccupant';
+export type { Profile, CreateProfileData } from './Profile';

--- a/libs/validators/src/index.ts
+++ b/libs/validators/src/index.ts
@@ -2,3 +2,4 @@ export * from './auth';
 export * from './property';
 export * from './person';
 export * from './lease';
+export * from './profile';

--- a/libs/validators/src/profile/index.ts
+++ b/libs/validators/src/profile/index.ts
@@ -1,0 +1,1 @@
+export { updateProfileSchema, type UpdateProfileInput } from './update';

--- a/libs/validators/src/profile/update.test.ts
+++ b/libs/validators/src/profile/update.test.ts
@@ -1,0 +1,187 @@
+import { ZodError } from 'zod';
+import { updateProfileSchema } from './update';
+
+describe('updateProfileSchema', () => {
+  describe('valid data', () => {
+    it('should accept complete valid profile data with all fields', () => {
+      const validData = {
+        firstName: 'John',
+        lastName: 'Doe',
+        phone: '1234567890',
+      };
+
+      const result = updateProfileSchema.parse(validData);
+      expect(result).toEqual(validData);
+    });
+
+    it('should accept empty object (no update)', () => {
+      const validData = {};
+
+      const result = updateProfileSchema.parse(validData);
+      expect(result).toEqual({});
+    });
+
+    it('should accept partial update with only firstName', () => {
+      const validData = {
+        firstName: 'Jane',
+      };
+
+      const result = updateProfileSchema.parse(validData);
+      expect(result).toEqual(validData);
+    });
+
+    it('should accept partial update with only lastName', () => {
+      const validData = {
+        lastName: 'Smith',
+      };
+
+      const result = updateProfileSchema.parse(validData);
+      expect(result).toEqual(validData);
+    });
+
+    it('should accept partial update with only phone', () => {
+      const validData = {
+        phone: '5551234567',
+      };
+
+      const result = updateProfileSchema.parse(validData);
+      expect(result).toEqual(validData);
+    });
+
+    it('should accept maximum length firstName', () => {
+      const validData = {
+        firstName: 'A'.repeat(100),
+      };
+
+      expect(() => updateProfileSchema.parse(validData)).not.toThrow();
+    });
+
+    it('should accept maximum length lastName', () => {
+      const validData = {
+        lastName: 'B'.repeat(100),
+      };
+
+      expect(() => updateProfileSchema.parse(validData)).not.toThrow();
+    });
+
+    it('should accept maximum length phone', () => {
+      const validData = {
+        phone: '1'.repeat(20),
+      };
+
+      expect(() => updateProfileSchema.parse(validData)).not.toThrow();
+    });
+
+    it('should accept minimum length phone', () => {
+      const validData = {
+        phone: '1234567890', // exactly 10 digits
+      };
+
+      expect(() => updateProfileSchema.parse(validData)).not.toThrow();
+    });
+  });
+
+  describe('field length validation', () => {
+    it('should reject firstName longer than 100 characters', () => {
+      const invalidData = {
+        firstName: 'A'.repeat(101),
+      };
+
+      expect(() => updateProfileSchema.parse(invalidData)).toThrow(ZodError);
+    });
+
+    it('should reject lastName longer than 100 characters', () => {
+      const invalidData = {
+        lastName: 'B'.repeat(101),
+      };
+
+      expect(() => updateProfileSchema.parse(invalidData)).toThrow(ZodError);
+    });
+
+    it('should reject phone longer than 20 characters', () => {
+      const invalidData = {
+        phone: '1'.repeat(21),
+      };
+
+      expect(() => updateProfileSchema.parse(invalidData)).toThrow(ZodError);
+    });
+
+    it('should reject phone shorter than 10 characters', () => {
+      const invalidData = {
+        phone: '123456789', // 9 digits
+      };
+
+      expect(() => updateProfileSchema.parse(invalidData)).toThrow(ZodError);
+    });
+
+    it('should reject empty firstName when provided', () => {
+      const invalidData = {
+        firstName: '',
+      };
+
+      expect(() => updateProfileSchema.parse(invalidData)).toThrow(ZodError);
+    });
+
+    it('should reject empty lastName when provided', () => {
+      const invalidData = {
+        lastName: '',
+      };
+
+      expect(() => updateProfileSchema.parse(invalidData)).toThrow(ZodError);
+    });
+
+    it('should reject empty phone when provided', () => {
+      const invalidData = {
+        phone: '',
+      };
+
+      expect(() => updateProfileSchema.parse(invalidData)).toThrow(ZodError);
+    });
+  });
+
+  describe('strict mode validation', () => {
+    it('should reject unknown fields', () => {
+      const invalidData = {
+        firstName: 'John',
+        unknownField: 'value',
+      };
+
+      expect(() => updateProfileSchema.parse(invalidData)).toThrow(ZodError);
+    });
+
+    it('should reject userId field (not updatable)', () => {
+      const invalidData = {
+        firstName: 'John',
+        userId: 'user-123',
+      };
+
+      expect(() => updateProfileSchema.parse(invalidData)).toThrow(ZodError);
+    });
+  });
+
+  describe('type validation', () => {
+    it('should reject non-string firstName', () => {
+      const invalidData = {
+        firstName: 123,
+      };
+
+      expect(() => updateProfileSchema.parse(invalidData)).toThrow(ZodError);
+    });
+
+    it('should reject non-string lastName', () => {
+      const invalidData = {
+        lastName: 456,
+      };
+
+      expect(() => updateProfileSchema.parse(invalidData)).toThrow(ZodError);
+    });
+
+    it('should reject non-string phone', () => {
+      const invalidData = {
+        phone: 1234567890,
+      };
+
+      expect(() => updateProfileSchema.parse(invalidData)).toThrow(ZodError);
+    });
+  });
+});

--- a/libs/validators/src/profile/update.ts
+++ b/libs/validators/src/profile/update.ts
@@ -1,0 +1,9 @@
+import { z } from 'zod';
+
+export const updateProfileSchema = z.object({
+  firstName: z.string().min(1, 'First name cannot be empty').max(100, 'First name too long').optional(),
+  lastName: z.string().min(1, 'Last name cannot be empty').max(100, 'Last name too long').optional(),
+  phone: z.string().min(10, 'Phone number must be at least 10 digits').max(20, 'Phone number too long').optional(),
+}).strict();
+
+export type UpdateProfileInput = z.infer<typeof updateProfileSchema>;


### PR DESCRIPTION
## Summary
- Implements Profile entity separate from User entity following Clean Architecture
- Adds `GET /api/profile` endpoint (auto-creates profile if not exists)
- Adds `PUT /api/profile` endpoint with validation for field updates
- Includes Flyway migration with backfill for existing users

## Changes
### Domain Layer
- Added `Profile` and `CreateProfileData` interfaces in `libs/domain/src/entities/Profile.ts`

### Validators
- Added Zod schema for profile updates in `libs/validators/src/profile/`
- Validation rules: firstName (1-100 chars), lastName (1-100 chars), phone (10-20 chars)

### Repository Layer
- Added `IProfileRepository` interface
- Added `PrismaProfileRepository` implementation

### Use Cases (TDD)
- `GetProfileUseCase` - Get-or-create pattern (auto-creates empty profile)
- `UpdateProfileUseCase` - Validates input, supports partial updates

### Presentation Layer
- `ProfileController` - Thin HTTP routing layer
- `profileRoutes` - Protected by auth middleware

### Database
- Prisma schema updated with Profile model (1:1 with User)
- Flyway migration `V2__add_profiles_table.sql` with backfill

## Test plan
- [x] Unit tests: 10 new tests (3 GetProfile + 7 UpdateProfile)
- [x] Validator tests: 21 new tests for profile schema
- [x] All 382 tests passing
- [x] TypeScript build succeeds
- [x] Dev server starts without errors

## API Endpoints
| Method | Endpoint | Description | Auth |
|--------|----------|-------------|------|
| GET | `/api/profile` | Get current user's profile | JWT |
| PUT | `/api/profile` | Update current user's profile | JWT |

🤖 Generated with [Claude Code](https://claude.com/claude-code)