### PR TITLE
fix: Use TEXT type for profile migration to match existing schema

### DIFF
--- a/apps/backend/migrations/V2__add_profiles_table.sql
+++ b/apps/backend/migrations/V2__add_profiles_table.sql
@@ -1,24 +1,36 @@
 -- Create profiles table
-CREATE TABLE profiles (
-    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    user_id UUID NOT NULL UNIQUE,
-    first_name VARCHAR(100) NOT NULL DEFAULT '',
-    last_name VARCHAR(100) NOT NULL DEFAULT '',
-    phone VARCHAR(20) NOT NULL DEFAULT '',
-    created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-    updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+CREATE TABLE "profiles" (
+    "id" TEXT NOT NULL,
+    "user_id" TEXT NOT NULL,
+    "first_name" VARCHAR(100) NOT NULL DEFAULT '',
+    "last_name" VARCHAR(100) NOT NULL DEFAULT '',
+    "phone" VARCHAR(20) NOT NULL DEFAULT '',
+    "created_at" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updated_at" TIMESTAMP(3) NOT NULL,
 
-    CONSTRAINT fk_profile_user FOREIGN KEY (user_id)
-        REFERENCES users(id) ON DELETE CASCADE
+    CONSTRAINT "profiles_pkey" PRIMARY KEY ("id")
 );
 
+-- Create unique index on user_id (1:1 relationship)
+CREATE UNIQUE INDEX "profiles_user_id_key" ON "profiles"("user_id");
+
 -- Create index on user_id for faster lookups
-CREATE INDEX idx_profiles_user_id ON profiles(user_id);
+CREATE INDEX "profiles_user_id_idx" ON "profiles"("user_id");
+
+-- AddForeignKey
+ALTER TABLE "profiles" ADD CONSTRAINT "profiles_user_id_fkey" FOREIGN KEY ("user_id") REFERENCES "users"("id") ON DELETE CASCADE ON UPDATE CASCADE;
 
 -- Backfill existing users with empty profiles
-INSERT INTO profiles (user_id, first_name, last_name, phone)
-SELECT id, '', '', ''
-FROM users
+INSERT INTO "profiles" ("id", "user_id", "first_name", "last_name", "phone", "created_at", "updated_at")
+SELECT
+    gen_random_uuid()::text,
+    "id",
+    '',
+    '',
+    '',
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+FROM "users"
 WHERE NOT EXISTS (
-    SELECT 1 FROM profiles WHERE profiles.user_id = users.id
+    SELECT 1 FROM "profiles" WHERE "profiles"."user_id" = "users"."id"
 );


### PR DESCRIPTION
## Summary
- Fixes Flyway migration failure due to type mismatch between profiles table and users table

## Problem
The V2 migration used `UUID` type for `id` and `user_id` columns, but the production database uses `TEXT` type for all IDs (as defined in V1__init.sql).

Error message:
```
ERROR: foreign key constraint "fk_profile_user" cannot be implemented
Detail: Key columns "user_id" of the referencing table and "id" of the referenced table are of incompatible types: uuid and text.
```

## Fix
Updated migration to match V1 schema conventions:
- Changed `id` and `user_id` from `UUID` to `TEXT`
- Changed `TIMESTAMP` to `TIMESTAMP(3)`
- Added proper quoted identifiers
- Fixed naming conventions (`_pkey`, `_fkey` suffixes)

## Test plan
- [x] Migration syntax matches V1__init.sql conventions
- [ ] Flyway migration runs successfully on production

🤖 Generated with [Claude Code](https://claude.com/claude-code)